### PR TITLE
Remove Facebook Like button

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,6 @@
     <style type="text/css">
       body {
         font-family: Arial, sans-serif;
-        background-color: #ddd;
       }
       h1 {
         margin-top: 1.5em;

--- a/index.html
+++ b/index.html
@@ -129,13 +129,6 @@
       For a longer guide on proper bug reporting, please check
       <a href="/tatham/en.html">Simon Tatham's excellent article</a>.
     </p>
-    <hr>
-    <div class="fb-like"
-      data-href="http://yourbugreportneedsmore.info/"
-      data-send="false"
-      data-width="450"
-      data-show-faces="false">
-    </div>
     <footer>
       By <a href="http://twitter.com/compay">@compay</a>
       <a href="https://github.com/norman/yourbugreportneedsmore.info">Fork me</a>
@@ -143,5 +136,3 @@
     </div>
   </body>
 </html>
-
-


### PR DESCRIPTION
Facebook doesn't track only the time we spend on the site: the Like
button sends over our information too wherever it is displayed.

It is our personal opinion how much there is to lose around privacy
with tracking scripts like these. If awareness of this website doesn't
grow because of the presence of the button there is nothing to gain
either.

See:
- http://www.technologyreview.com/news/541351/facebooks-like-buttons-will-soon-track-your-web-browsing-to-target-ads/
- http://edition.cnn.com/2010/TECH/social.media/06/02/cnet.facebook.privacy.like/index.html
- https://www.eff.org/privacybadger

This patch also:
- Removes extra new lines from the end of the file
- Removes ugly gray background I once chose

Thank you!
